### PR TITLE
Only condense own team if to many pokemon are displayed

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -754,7 +754,7 @@ async function updateSidebarCards(partyID, sessionData, pokemonData) {
     let css_class_condensed = '';
 
     /* Change the sidebar view to a more condensed version when more than 8 pokemon are fighting. (Olny some trianer battles) */
-    if ((enemyPartySize + allyPartySize) > maxPokemonForDetailedView) {
+    if ((enemyPartySize + allyPartySize) > maxPokemonForDetailedView && partyID == 'allies') {
         css_class_condensed = 'condensed';
     }
 


### PR DESCRIPTION
This will still let you know all the enemy infos and just condense your own team since you should know the info from your own team.

![grafik](https://github.com/Eruyome/roguedex/assets/16718523/c0f70198-29c9-498e-8fef-296d3150ecb1)
